### PR TITLE
feat: implement Bernoulli kite lab interactive page

### DIFF
--- a/kite-lab/README.md
+++ b/kite-lab/README.md
@@ -1,0 +1,125 @@
+# 伯努利风筝实验室（第七页交互）
+
+这是一个基于 Vite + TypeScript + p5.js 实现的 H5 交互单页，支持 iframe 嵌入与 UMD 方式挂载。学生可以通过风势、提线角、拉力三个参数探索伯努利原理，并完成“稳定飞行≥2秒”的目标。
+
+## 功能亮点
+
+- **三参数操控**：风势、提线角、拉力滑条，支持两参数降级模式。
+- **教学模式**：显示升力/重力/拉力向量及数值，辅助讲解。
+- **性能模式**：关闭粒子气流等特效，保障低端设备流畅。
+- **成绩回调**：稳定判定达标后通过 `postMessage` 与外部回调同步。
+- **状态持久化**：通过 LocalStorage 与 URL Hash 记忆上次成绩与参数。
+
+## 快速开始
+
+```bash
+npm install
+npm run dev
+```
+
+开发服务器启动后访问 `http://localhost:5173` 即可实时预览。
+
+## 构建与产物
+
+```bash
+npm run build
+```
+
+构建完成后生成：
+
+- `dist/index.html`：iframe 直接引入的页面（资源均为相对路径）。
+- `dist/kite-lab.umd.js`：可在父页面直接挂载的 UMD 包（全局 `window.KiteLab`）。
+
+如需本地预览打包结果：
+
+```bash
+npm run preview
+```
+
+## 单元测试
+
+项目使用 Vitest 针对物理模型进行单测。
+
+```bash
+npm run test
+```
+
+## API 概览
+
+所有类型定义见 `src/types.ts`。
+
+```ts
+import { KiteLab, InitOptions } from 'kite-lab';
+
+KiteLab.mount(container, options);  // UMD 方式
+KiteLab.init(options);              // iframe 内部自初始化
+KiteLab.setTheme('ink');
+KiteLab.setLocale('en');
+KiteLab.setParams({ wind: 3 });
+const state = KiteLab.getState();
+KiteLab.reset();
+KiteLab.destroy();
+```
+
+`InitOptions` 主要字段：
+
+- `theme`: `'light' | 'ink' | 'auto'`
+- `locale`: `'zh' | 'en'`
+- `mode`: `'learn' | 'quiz'`
+- `defaultParams`: `{ wind, angle, tension }`
+- `enableParticles`: 布尔值，是否默认开启气流粒子
+- `twoParamMode`: 布尔值，是否启用两参数模式
+- `onReady` / `onScore` / `onStateChange` / `onEnd`: 生命周期回调
+
+## iframe 与父页通信
+
+所有消息均包含 `source/target: 'kite-lab'` 字段。
+
+### 子页发送
+
+- `ready`：准备完毕
+- `state`：状态快照
+- `score`：得分 `{ stableSec, attempts, passed }`
+- `end`：销毁通知
+
+```js
+window.addEventListener('message', (event) => {
+  if (event.data?.source !== 'kite-lab') return;
+  const { type, payload } = event.data;
+  if (type === 'score') {
+    console.log('稳定飞行', payload);
+  }
+});
+```
+
+### 父页指令
+
+- `set-theme`
+- `set-locale`
+- `set-params`
+- `reset`
+- `get-state`
+
+```js
+iframe.contentWindow?.postMessage({
+  target: 'kite-lab',
+  type: 'set-params',
+  payload: { wind: 3, angle: 20 }
+}, '*');
+```
+
+## 目录结构
+
+```
+kite-lab/
+├── public/            # iframe 模板
+├── src/               # TypeScript 源码
+├── test/              # Vitest 单测
+├── vite.config.ts     # 构建配置（含 UMD 输出）
+├── tsconfig.json
+└── package.json
+```
+
+## 授权
+
+本项目仅用于教学演示，可按需二次开发与部署。

--- a/kite-lab/index.html
+++ b/kite-lab/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="zh">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>伯努利风筝实验室</title>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="/src/index.ts"></script>
+  </body>
+</html>

--- a/kite-lab/package.json
+++ b/kite-lab/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "kite-lab",
+  "version": "1.0.0",
+  "description": "伯努利风筝实验室（第七页交互）",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview",
+    "test": "vitest"
+  },
+  "dependencies": {
+    "p5": "^1.9.0"
+  },
+  "devDependencies": {
+    "@types/p5": "^1.6.3",
+    "@vitest/coverage-v8": "^0.34.6",
+    "typescript": "^5.3.3",
+    "vite": "^5.0.0",
+    "vitest": "^0.34.6"
+  }
+}

--- a/kite-lab/public/index.html
+++ b/kite-lab/public/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="zh">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>伯努利风筝实验室</title>
+    <link rel="stylesheet" href="./assets/style.css" />
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="./assets/index.js"></script>
+  </body>
+</html>

--- a/kite-lab/src/controls.ts
+++ b/kite-lab/src/controls.ts
@@ -1,0 +1,269 @@
+import type { KiteParams } from './types';
+import { clamp } from './utils';
+
+export interface ControlsConfig {
+  container: HTMLElement;
+  params: KiteParams;
+  locale: 'zh' | 'en';
+  mode: 'learn' | 'quiz';
+  twoParamMode: boolean;
+  enableParticles: boolean;
+  onParamsChange: (params: KiteParams) => void;
+  onReset: () => void;
+  onTeachToggle: (value: boolean) => void;
+  onParticleToggle: (value: boolean) => void;
+  onTwoParamToggle: (value: boolean) => void;
+}
+
+export interface ControlsHandle {
+  setParams(params: Partial<KiteParams>): void;
+  setLocale(locale: 'zh' | 'en'): void;
+  setTwoParamMode(enabled: boolean): void;
+  setParticlesEnabled(enabled: boolean): void;
+  setTeachMode(enabled: boolean): void;
+  destroy(): void;
+}
+
+const STRINGS = {
+  zh: {
+    title: '伯努利风筝实验室',
+    wind: '风势',
+    angle: '提线角',
+    tension: '拉力',
+    reset: '重置',
+    teach: '教学开关',
+    particles: '气流粒子',
+    twoParam: '两参数模式'
+  },
+  en: {
+    title: "Bernoulli's Kite Lab",
+    wind: 'Wind',
+    angle: 'Angle',
+    tension: 'Tension',
+    reset: 'Reset',
+    teach: 'Instruction',
+    particles: 'Particles',
+    twoParam: 'Two-parameter mode'
+  }
+};
+
+export function createControls(config: ControlsConfig): ControlsHandle {
+  const state = { ...config.params };
+  let teachMode = config.mode === 'learn';
+  let particles = config.enableParticles;
+  let currentLocale = config.locale;
+  let twoParam = config.twoParamMode;
+
+  const panel = document.createElement('div');
+  panel.className = 'kite-panel';
+
+  const title = document.createElement('h1');
+  panel.appendChild(title);
+
+  const slidersWrapper = document.createElement('div');
+  slidersWrapper.style.display = 'flex';
+  slidersWrapper.style.flexDirection = 'column';
+  slidersWrapper.style.gap = '16px';
+  panel.appendChild(slidersWrapper);
+
+  const windSlider = createSlider('wind', 0, 5, 0.1, state.wind);
+  const angleSlider = createSlider('angle', 5, 35, 0.5, state.angle);
+  const tensionSlider = createSlider('tension', 0.8, 1.2, 0.01, state.tension);
+
+  slidersWrapper.appendChild(windSlider.wrapper);
+  slidersWrapper.appendChild(angleSlider.wrapper);
+  slidersWrapper.appendChild(tensionSlider.wrapper);
+
+  const toggles = document.createElement('div');
+  toggles.style.display = 'flex';
+  toggles.style.flexDirection = 'column';
+  toggles.style.gap = '12px';
+  panel.appendChild(toggles);
+
+  const teachToggle = createToggle('teach', teachMode);
+  const particleToggle = createToggle('particles', particles);
+  const twoParamToggle = createToggle('twoParam', twoParam);
+
+  toggles.appendChild(teachToggle.wrapper);
+  toggles.appendChild(particleToggle.wrapper);
+  toggles.appendChild(twoParamToggle.wrapper);
+
+  const actions = document.createElement('div');
+  actions.className = 'kite-actions';
+  const resetBtn = document.createElement('button');
+  resetBtn.className = 'kite-button';
+  actions.appendChild(resetBtn);
+  panel.appendChild(actions);
+
+  config.container.appendChild(panel);
+
+  const refreshSliderValues = () => {
+    windSlider.value.textContent = state.wind.toFixed(1);
+    angleSlider.value.textContent = `${state.angle.toFixed(1)}°`;
+    tensionSlider.value.textContent = state.tension.toFixed(2);
+  };
+
+  const updateLocaleTexts = () => {
+    const strings = STRINGS[currentLocale];
+    title.textContent = strings.title;
+    [windSlider, angleSlider, tensionSlider].forEach((slider) => {
+      const key = slider.label.dataset.key as keyof typeof strings;
+      slider.label.firstChild && (slider.label.firstChild.textContent = strings[key]);
+    });
+    teachToggle.label.textContent = strings.teach;
+    particleToggle.label.textContent = strings.particles;
+    twoParamToggle.label.textContent = strings.twoParam;
+    resetBtn.textContent = strings.reset;
+    refreshSliderValues();
+  };
+
+  function emitParams() {
+    config.onParamsChange({ ...state });
+  }
+
+  windSlider.input.addEventListener('input', () => {
+    state.wind = clamp(Number(windSlider.input.value), 0, 5);
+    refreshSliderValues();
+    emitParams();
+  });
+
+  angleSlider.input.addEventListener('input', () => {
+    state.angle = clamp(Number(angleSlider.input.value), 5, 35);
+    refreshSliderValues();
+    emitParams();
+  });
+
+  tensionSlider.input.addEventListener('input', () => {
+    state.tension = clamp(Number(tensionSlider.input.value), 0.8, 1.2);
+    refreshSliderValues();
+    emitParams();
+  });
+
+  teachToggle.input.addEventListener('change', () => {
+    teachMode = teachToggle.input.checked;
+    config.onTeachToggle(teachMode);
+  });
+
+  particleToggle.input.addEventListener('change', () => {
+    particles = particleToggle.input.checked;
+    config.onParticleToggle(particles);
+  });
+
+  twoParamToggle.input.addEventListener('change', () => {
+    twoParam = twoParamToggle.input.checked;
+    tensionSlider.wrapper.style.display = twoParam ? 'none' : '';
+    if (twoParam) {
+      state.tension = 1;
+      tensionSlider.input.value = '1';
+    }
+    refreshSliderValues();
+    emitParams();
+    config.onTwoParamToggle(twoParam);
+  });
+
+  tensionSlider.wrapper.style.display = twoParam ? 'none' : '';
+  updateLocaleTexts();
+
+  resetBtn.addEventListener('click', () => {
+    config.onReset();
+  });
+
+  return {
+    setParams(partial) {
+      if (partial.wind !== undefined) {
+        state.wind = clamp(partial.wind, 0, 5);
+        windSlider.input.value = state.wind.toString();
+      }
+      if (partial.angle !== undefined) {
+        state.angle = clamp(partial.angle, 5, 35);
+        angleSlider.input.value = state.angle.toString();
+      }
+      if (partial.tension !== undefined) {
+        state.tension = clamp(partial.tension, 0.8, 1.2);
+        tensionSlider.input.value = state.tension.toString();
+      }
+      refreshSliderValues();
+    },
+    setLocale(locale) {
+      currentLocale = locale;
+      updateLocaleTexts();
+    },
+    setTwoParamMode(enabled) {
+      twoParam = enabled;
+      twoParamToggle.input.checked = enabled;
+      tensionSlider.wrapper.style.display = enabled ? 'none' : '';
+      if (enabled) {
+        state.tension = 1;
+        tensionSlider.input.value = '1';
+      }
+      refreshSliderValues();
+      emitParams();
+      config.onTwoParamToggle(enabled);
+    },
+    setParticlesEnabled(enabled) {
+      particles = enabled;
+      particleToggle.input.checked = enabled;
+      config.onParticleToggle(enabled);
+    },
+    setTeachMode(enabled) {
+      teachMode = enabled;
+      teachToggle.input.checked = enabled;
+      config.onTeachToggle(enabled);
+    },
+    destroy() {
+      config.container.removeChild(panel);
+    }
+  };
+}
+
+type SliderElements = {
+  wrapper: HTMLDivElement;
+  label: HTMLLabelElement;
+  input: HTMLInputElement;
+  value: HTMLSpanElement;
+};
+
+function createSlider(
+  key: keyof KiteParams,
+  min: number,
+  max: number,
+  step: number,
+  value: number
+): SliderElements {
+  const wrapper = document.createElement('div');
+  wrapper.className = 'kite-slider';
+  const label = document.createElement('label');
+  label.dataset.key = key;
+  const textSpan = document.createElement('span');
+  label.appendChild(textSpan);
+  const valueSpan = document.createElement('span');
+  label.appendChild(valueSpan);
+  const input = document.createElement('input');
+  input.type = 'range';
+  input.min = String(min);
+  input.max = String(max);
+  input.step = String(step);
+  input.value = String(value);
+  wrapper.appendChild(label);
+  wrapper.appendChild(input);
+  return { wrapper, label, input, value: valueSpan };
+}
+
+type ToggleElements = {
+  wrapper: HTMLDivElement;
+  label: HTMLSpanElement;
+  input: HTMLInputElement;
+};
+
+function createToggle(key: 'teach' | 'particles' | 'twoParam', checked: boolean): ToggleElements {
+  const wrapper = document.createElement('div');
+  wrapper.className = 'kite-toggle';
+  const label = document.createElement('span');
+  label.dataset.key = key;
+  const input = document.createElement('input');
+  input.type = 'checkbox';
+  input.checked = checked;
+  wrapper.appendChild(label);
+  wrapper.appendChild(input);
+  return { wrapper, label, input };
+}

--- a/kite-lab/src/index.ts
+++ b/kite-lab/src/index.ts
@@ -1,0 +1,303 @@
+import './theme.css';
+import { createControls } from './controls';
+import { createScene } from './scene';
+import { createMessaging } from './messaging';
+import { PHYSICS_CONSTANTS, createInitialState, stepState } from './physics';
+import {
+  getDefaultParams,
+  loadPersistedState,
+  parseHashParams,
+  savePersistedState,
+  writeHashParams
+} from './utils';
+import type { InitOptions, KiteParams, KiteState, Score } from './types';
+
+const TEXT = {
+  zh: {
+    weak: '风势不足，试试加风或抬一点角度',
+    stall: '角度过大，容易失速哦～',
+    stable: '稳稳当当！'
+  },
+  en: {
+    weak: 'Wind is weak, add more wind or lift the angle!',
+    stall: 'Angle too high, you are stalling!',
+    stable: 'Stable airflow!'
+  }
+};
+
+interface Runtime {
+  container: HTMLElement;
+  canvasWrap: HTMLElement;
+  controlsWrap: HTMLElement;
+}
+
+let runtime: Runtime | null = null;
+let sceneHandle: ReturnType<typeof createScene> | null = null;
+let controlsHandle: ReturnType<typeof createControls> | null = null;
+let messagingHandle: ReturnType<typeof createMessaging> | null = null;
+let currentOptions: InitOptions | null = null;
+let currentParams: KiteParams;
+let currentState: KiteState;
+let teachMode = true;
+let particlesEnabled = true;
+let locale: 'zh' | 'en' = 'zh';
+let theme: 'light' | 'ink' | 'auto' = 'light';
+let twoParamMode = false;
+let lastScoreReported = false;
+let rafId = 0;
+let running = false;
+let lastStateEmit = 0;
+let attempts = 1;
+let lastToastType: 'weak' | 'stall' | 'stable' | '' = '';
+let lastToastAt = 0;
+const TOAST_COOLDOWN = 2400;
+
+function resolveContainer(options?: InitOptions): HTMLElement {
+  if (options?.container) {
+    return options.container;
+  }
+  const el = document.getElementById('app');
+  if (!el) throw new Error('[kite-lab] 未找到挂载容器 #app');
+  return el;
+}
+
+function setupLayout(container: HTMLElement): Runtime {
+  container.innerHTML = '';
+  container.classList.add('kite-container');
+  const canvasWrap = document.createElement('div');
+  canvasWrap.className = 'kite-canvas';
+  const controlsWrap = document.createElement('div');
+  controlsWrap.className = 'kite-controls';
+  container.appendChild(canvasWrap);
+  container.appendChild(controlsWrap);
+  return { container, canvasWrap, controlsWrap };
+}
+
+function applyTheme(next: 'light' | 'ink' | 'auto') {
+  theme = next;
+  const root = document.documentElement;
+  const resolved = next === 'auto' && window.matchMedia('(prefers-color-scheme: dark)').matches ? 'ink' : next;
+  root.setAttribute('data-theme', resolved);
+}
+
+function startLoop() {
+  if (running) return;
+  running = true;
+  const loop = (time: number) => {
+    if (!running) return;
+    const seconds = time / 1000;
+    const params = { ...currentParams };
+    if (twoParamMode) {
+      params.tension = 1;
+    }
+    currentState = stepState(currentState, params, seconds);
+    handleStateUpdate(currentState);
+    rafId = window.requestAnimationFrame(loop);
+  };
+  rafId = window.requestAnimationFrame(loop);
+}
+
+function stopLoop() {
+  running = false;
+  if (rafId) {
+    cancelAnimationFrame(rafId);
+    rafId = 0;
+  }
+}
+
+function handleStateUpdate(state: KiteState) {
+  const now = performance.now();
+  if (currentOptions?.onStateChange) {
+    currentOptions.onStateChange(state);
+  }
+  if (messagingHandle && now - lastStateEmit > 200) {
+    messagingHandle.postState(state);
+    lastStateEmit = now;
+  }
+  if (!lastScoreReported && state.passed) {
+    lastScoreReported = true;
+    const score: Score = {
+      stableSec: state.stableSeconds,
+      attempts,
+      passed: true
+    };
+    currentOptions?.onScore?.(score);
+    messagingHandle?.postScore(score);
+    showToast('stable');
+    savePersistedState({ params: state.params, score });
+  }
+  if (!state.passed) {
+    lastScoreReported = false;
+  }
+  if (state.stableSeconds === 0 && state.lift < state.gravity && state.params.wind < 1.2) {
+    showToast('weak');
+  }
+  if (state.stableSeconds === 0 && state.pitch > PHYSICS_CONSTANTS.stallAlpha + 4) {
+    showToast('stall');
+  }
+  writeHashParams(state.params);
+}
+
+function showToast(type: 'weak' | 'stall' | 'stable') {
+  if (!sceneHandle) return;
+  const now = performance.now();
+  if (lastToastType === type && now - lastToastAt < TOAST_COOLDOWN) {
+    return;
+  }
+  lastToastType = type;
+  lastToastAt = now;
+  sceneHandle.showToast(TEXT[locale][type]);
+}
+
+function buildInitialParams(options?: InitOptions): KiteParams {
+  const persisted = loadPersistedState();
+  const hash = parseHashParams();
+  const defaults = getDefaultParams({ ...persisted?.params, ...options?.defaultParams, ...hash });
+  const useTwoParam = options?.twoParamMode ?? twoParamMode;
+  return {
+    wind: defaults.wind,
+    angle: defaults.angle,
+    tension: useTwoParam ? 1 : defaults.tension
+  };
+}
+
+function setup(options?: InitOptions) {
+  currentOptions = options ?? null;
+  locale = options?.locale ?? 'zh';
+  theme = options?.theme ?? 'light';
+  twoParamMode = options?.twoParamMode ?? false;
+  teachMode = options?.mode === 'quiz' ? false : true;
+  particlesEnabled = options?.enableParticles ?? true;
+  applyTheme(theme);
+  const container = resolveContainer(options);
+  runtime = setupLayout(container);
+  currentParams = buildInitialParams(options);
+  attempts = 1;
+  currentState = createInitialState(currentParams, 0);
+  currentState.attempts = attempts;
+  lastScoreReported = false;
+
+  sceneHandle = createScene({
+    container: runtime.canvasWrap,
+    getState: () => currentState,
+    getParams: () => currentParams,
+    showVectors: () => teachMode,
+    enableParticles: () => particlesEnabled,
+    locale: () => locale
+  });
+
+  controlsHandle = createControls({
+    container: runtime.controlsWrap,
+    params: currentParams,
+    locale,
+    mode: options?.mode ?? 'learn',
+    twoParamMode,
+    enableParticles: particlesEnabled,
+    onParamsChange: (params) => {
+      currentParams = { ...params };
+      if (twoParamMode) currentParams.tension = 1;
+    },
+    onReset: () => {
+      reset();
+    },
+    onTeachToggle: (value) => {
+      teachMode = value;
+    },
+    onParticleToggle: (value) => {
+      particlesEnabled = value;
+    },
+    onTwoParamToggle: (value) => {
+      twoParamMode = value;
+    }
+  });
+
+  controlsHandle.setTwoParamMode(twoParamMode);
+
+  messagingHandle = createMessaging({
+    getState: () => currentState,
+    onLocale: (value) => setLocale(value),
+    onTheme: (value) => setTheme(value),
+    onParams: (value) => setParams(value),
+    onReset: () => reset()
+  });
+
+  messagingHandle.postReady();
+  currentOptions?.onReady?.();
+
+  startLoop();
+}
+
+function ensureSetup() {
+  if (!runtime) throw new Error('[kite-lab] 组件尚未初始化');
+}
+
+function setTheme(value: 'light' | 'ink' | 'auto') {
+  applyTheme(value);
+}
+
+function setLocale(value: 'zh' | 'en') {
+  locale = value;
+  controlsHandle?.setLocale(value);
+}
+
+function setParams(partial: Partial<KiteParams>) {
+  ensureSetup();
+  currentParams = { ...currentParams, ...partial };
+  if (twoParamMode) currentParams.tension = 1;
+  controlsHandle?.setParams(currentParams);
+}
+
+function getState(): KiteState {
+  ensureSetup();
+  return currentState;
+}
+
+function reset() {
+  ensureSetup();
+  attempts += 1;
+  currentParams = buildInitialParams(currentOptions ?? undefined);
+  controlsHandle?.setParams(currentParams);
+  currentState = createInitialState(currentParams, 0);
+  currentState.attempts = attempts;
+  lastScoreReported = false;
+  showToast('weak');
+}
+
+function destroy() {
+  stopLoop();
+  messagingHandle?.postEnd();
+  messagingHandle?.dispose();
+  messagingHandle = null;
+  sceneHandle?.destroy();
+  sceneHandle = null;
+  controlsHandle?.destroy();
+  controlsHandle = null;
+  runtime = null;
+}
+
+function mount(el: HTMLElement, options?: InitOptions) {
+  setup({ ...options, container: el });
+}
+
+function init(options?: InitOptions) {
+  const container = resolveContainer(options);
+  setup({ ...options, container });
+}
+
+const KiteLab = {
+  mount,
+  init,
+  setTheme,
+  setLocale,
+  setParams,
+  getState,
+  reset,
+  destroy
+};
+
+if (typeof window !== 'undefined') {
+  (window as unknown as { KiteLab?: typeof KiteLab }).KiteLab = KiteLab;
+}
+
+export type { InitOptions, KiteState, KiteParams, Score };
+export { KiteLab };

--- a/kite-lab/src/messaging.ts
+++ b/kite-lab/src/messaging.ts
@@ -1,0 +1,68 @@
+import type { KiteState, MessageFromChild, MessageToChild } from './types';
+
+export interface MessagingConfig {
+  getState: () => KiteState;
+  onTheme?: (theme: 'light' | 'ink' | 'auto') => void;
+  onLocale?: (locale: 'zh' | 'en') => void;
+  onParams?: (params: Partial<{ wind: number; angle: number; tension: number }>) => void;
+  onReset?: () => void;
+}
+
+export interface MessagingHandle {
+  dispose(): void;
+  postReady(): void;
+  postState(state?: KiteState): void;
+  postScore(score: { stableSec: number; attempts: number; passed: boolean }): void;
+  postEnd(): void;
+}
+
+export function createMessaging(config: MessagingConfig): MessagingHandle {
+  const handler = (event: MessageEvent<MessageToChild>) => {
+    const data = event.data;
+    if (!data || data.target !== 'kite-lab') return;
+    switch (data.type) {
+      case 'set-theme':
+        config.onTheme?.(data.payload);
+        break;
+      case 'set-locale':
+        config.onLocale?.(data.payload);
+        break;
+      case 'set-params':
+        config.onParams?.(data.payload);
+        break;
+      case 'reset':
+        config.onReset?.();
+        break;
+      case 'get-state':
+        postToParent({ source: 'kite-lab', type: 'state', payload: config.getState() });
+        break;
+      default:
+        break;
+    }
+  };
+
+  window.addEventListener('message', handler);
+
+  return {
+    dispose() {
+      window.removeEventListener('message', handler);
+    },
+    postReady() {
+      postToParent({ source: 'kite-lab', type: 'ready' });
+    },
+    postState(state) {
+      postToParent({ source: 'kite-lab', type: 'state', payload: state ?? config.getState() });
+    },
+    postScore(score) {
+      postToParent({ source: 'kite-lab', type: 'score', payload: score });
+    },
+    postEnd() {
+      postToParent({ source: 'kite-lab', type: 'end' });
+    }
+  };
+}
+
+function postToParent(message: MessageFromChild) {
+  if (typeof window === 'undefined') return;
+  window.parent?.postMessage(message, '*');
+}

--- a/kite-lab/src/physics.ts
+++ b/kite-lab/src/physics.ts
@@ -1,0 +1,146 @@
+import { clamp, gustNoise, mapWind } from './utils';
+import type { KiteParams, KiteState } from './types';
+
+/**
+ * 物理常量，可根据课堂反馈调参。
+ */
+export const PHYSICS_CONSTANTS = {
+  gravity: 1,
+  liftCoeff: 0.11,
+  dragCoeff: 0.12,
+  extraDragCoeff: 0.04,
+  baseDamping: 0.4,
+  stallAlpha: 18,
+  liftSlope: 0.08,
+  stallSlope: 0.04,
+  maxAlpha: 30,
+  dt: 1 / 60,
+  velocityClamp: 3,
+  heightClamp: 1.2,
+  pitchClamp: 45,
+  stablePitch: 5,
+  stableVelocity: 0.15,
+  stableDuration: 2
+} as const;
+
+/**
+ * 计算有效迎角。
+ */
+export function computeEffectiveAlpha(angle: number, pitch: number): number {
+  const alpha = angle - pitch;
+  return clamp(alpha, 0, PHYSICS_CONSTANTS.maxAlpha);
+}
+
+/**
+ * 计算升力。
+ */
+export function computeLift(windSpeed: number, alpha: number): number {
+  const { liftCoeff, liftSlope, stallAlpha, stallSlope } = PHYSICS_CONSTANTS;
+  const effectiveAlpha = clamp(alpha, 0, PHYSICS_CONSTANTS.maxAlpha);
+  const gain = effectiveAlpha <= stallAlpha
+    ? liftSlope * effectiveAlpha
+    : liftSlope * stallAlpha - stallSlope * (effectiveAlpha - stallAlpha);
+  const liftFactor = Math.max(gain, 0);
+  return liftCoeff * windSpeed * windSpeed * liftFactor;
+}
+
+/**
+ * 计算阻力。
+ */
+export function computeDrag(windSpeed: number, lift: number): number {
+  const { dragCoeff, extraDragCoeff } = PHYSICS_CONSTANTS;
+  return dragCoeff * windSpeed * windSpeed + extraDragCoeff * lift * lift;
+}
+
+/**
+ * 计算阻尼。
+ */
+export function computeDamping(tension: number): number {
+  return PHYSICS_CONSTANTS.baseDamping * clamp(tension, 0.6, 1.4);
+}
+
+/**
+ * 判定是否处于稳定状态。
+ */
+export function isStable(lift: number, gravity: number, pitch: number, velocityY: number): boolean {
+  return (
+    lift > gravity &&
+    Math.abs(pitch) <= PHYSICS_CONSTANTS.stablePitch &&
+    Math.abs(velocityY) <= PHYSICS_CONSTANTS.stableVelocity
+  );
+}
+
+/**
+ * 根据当前参数与状态进行积分，返回新的状态。
+ */
+export function stepState(prev: KiteState, params: KiteParams, time: number): KiteState {
+  const dt = PHYSICS_CONSTANTS.dt;
+  const baseWind = mapWind(params.wind);
+  const gust = gustNoise(params.wind, time);
+  const windSpeed = baseWind * gust;
+
+  const pitch = clamp(prev.pitch, -PHYSICS_CONSTANTS.pitchClamp, PHYSICS_CONSTANTS.pitchClamp);
+  const alpha = computeEffectiveAlpha(params.angle, pitch);
+  const lift = computeLift(windSpeed * params.tension, alpha);
+  const drag = computeDrag(windSpeed, lift);
+  const gravity = PHYSICS_CONSTANTS.gravity;
+
+  let velY = prev.velocity.y;
+  let posY = prev.position.y;
+
+  const verticalForce = lift - gravity - drag * 0.12 * Math.sign(velY);
+  velY += verticalForce * dt;
+  velY *= 1 - computeDamping(params.tension) * dt;
+  velY = clamp(velY, -PHYSICS_CONSTANTS.velocityClamp, PHYSICS_CONSTANTS.velocityClamp);
+
+  posY += velY * dt;
+  posY = clamp(posY, -PHYSICS_CONSTANTS.heightClamp, PHYSICS_CONSTANTS.heightClamp);
+
+  const targetPitch = alpha * 0.02;
+  const pitchDamping = computeDamping(params.tension) * 0.02;
+  const nextPitch = clamp(pitch + (targetPitch - pitch) * dt - pitchDamping, -PHYSICS_CONSTANTS.pitchClamp, PHYSICS_CONSTANTS.pitchClamp);
+
+  const stable = isStable(lift, gravity, nextPitch, velY);
+  const stableSeconds = stable ? prev.stableSeconds + dt : 0;
+  const passed = stableSeconds >= PHYSICS_CONSTANTS.stableDuration ? true : prev.passed;
+
+  return {
+    ...prev,
+    params,
+    velocity: { x: 0, y: velY },
+    position: { x: 0, y: posY },
+    pitch: nextPitch,
+    lift,
+    gravity,
+    drag,
+    stableSeconds,
+    passed,
+    timestamp: time
+  };
+}
+
+/**
+ * 初始化状态。
+ */
+export function createInitialState(params: KiteParams, timestamp = 0): KiteState {
+  return {
+    params,
+    velocity: { x: 0, y: 0 },
+    position: { x: 0, y: 0 },
+    pitch: 0,
+    lift: 0,
+    gravity: PHYSICS_CONSTANTS.gravity,
+    drag: 0,
+    stableSeconds: 0,
+    attempts: 1,
+    passed: false,
+    timestamp
+  };
+}
+
+/**
+ * 累积尝试次数。
+ */
+export function incrementAttempts(state: KiteState): KiteState {
+  return { ...state, attempts: state.attempts + 1, stableSeconds: 0, passed: false };
+}

--- a/kite-lab/src/scene.ts
+++ b/kite-lab/src/scene.ts
@@ -1,0 +1,228 @@
+import p5 from 'p5';
+import type { KiteParams, KiteState } from './types';
+
+export interface SceneConfig {
+  container: HTMLElement;
+  getState: () => KiteState;
+  getParams: () => KiteParams;
+  showVectors: () => boolean;
+  enableParticles: () => boolean;
+  locale: () => 'zh' | 'en';
+}
+
+export interface SceneHandle {
+  showToast(message: string): void;
+  destroy(): void;
+}
+
+type Particle = {
+  x: number;
+  y: number;
+  speed: number;
+  life: number;
+};
+
+const TOAST_LIFETIME = 2200;
+
+const TEXT = {
+  zh: {
+    lift: '升力',
+    gravity: '重力',
+    tension: '拉力',
+    stable: '稳稳当当！',
+    unstable: '调整风势与角度，让风筝稳住～'
+  },
+  en: {
+    lift: 'Lift',
+    gravity: 'Gravity',
+    tension: 'Tension',
+    stable: 'Stable airflow!',
+    unstable: 'Tune the wind & angle to stay steady!'
+  }
+};
+
+export function createScene(config: SceneConfig): SceneHandle {
+  let toastMessage = '';
+  let toastTimer = 0;
+  let canvas: p5.Renderer | null = null;
+  const particles: Particle[] = Array.from({ length: 60 }, (_, i) => ({
+    x: Math.random(),
+    y: Math.random(),
+    speed: 0.2 + Math.random() * 0.4,
+    life: (i / 60) * 400
+  }));
+
+  const sketch = (p: p5) => {
+    const tailPoints = Array.from({ length: 18 }, () => ({ x: 0, y: 0 }));
+
+    const resize = () => {
+      const { clientWidth, clientHeight } = config.container;
+      p.resizeCanvas(clientWidth, clientHeight);
+    };
+
+    p.setup = () => {
+      const { clientWidth, clientHeight } = config.container;
+      canvas = p.createCanvas(clientWidth, clientHeight);
+      canvas.parent(config.container);
+      p.pixelDensity(Math.min(window.devicePixelRatio, 2));
+    };
+
+    p.windowResized = resize;
+
+    p.draw = () => {
+      const state = config.getState();
+      const params = config.getParams();
+      const lang = config.locale();
+      const strings = TEXT[lang];
+      const w = p.width;
+      const h = p.height;
+
+      p.background(p.color('rgba(250, 250, 247, 1)'));
+      const gradientSteps = 8;
+      for (let i = 0; i < gradientSteps; i++) {
+        const alpha = p.map(i, 0, gradientSteps, 0, 60);
+        p.noStroke();
+        p.fill(11, 112, 180, alpha);
+        p.rect(0, (h / gradientSteps) * i, w, h / gradientSteps);
+      }
+
+      const centerX = w * 0.45;
+      const centerY = h * 0.45 + state.position.y * h * 0.08;
+      const size = Math.min(w, h) * 0.28;
+
+      const pitchRad = (state.pitch * Math.PI) / 180;
+      p.push();
+      p.translate(centerX, centerY);
+      p.rotate(-pitchRad);
+      p.noStroke();
+      p.fill(255, 244, 199);
+      p.triangle(-size * 0.6, 0, size * 0.2, -size * 0.5, size * 0.2, size * 0.5);
+      p.fill(180, 66, 38);
+      p.triangle(-size * 0.6, 0, -size * 0.1, -size * 0.35, -size * 0.1, size * 0.35);
+      p.fill(254, 223, 99);
+      p.triangle(size * 0.2, -size * 0.5, size * 0.2, size * 0.5, size * 0.55, 0);
+
+      // 尾带
+      const tailBase = { x: size * 0.55, y: 0 };
+      p.stroke(255, 200, 120);
+      p.strokeWeight(3);
+      p.noFill();
+      tailPoints.forEach((point, index) => {
+        const t = index / tailPoints.length;
+        const sway = Math.sin((state.timestamp + index * 0.1) * 2) * 12 * (1 - t);
+        point.x = tailBase.x + t * size * 0.6 + sway;
+        point.y = tailBase.y + Math.sin((state.velocity.y + index) * 1.5 + t * 4) * 10 * (1 - t);
+      });
+      p.beginShape();
+      p.vertex(tailBase.x, tailBase.y);
+      tailPoints.forEach((point) => {
+        p.curveVertex(point.x, point.y);
+      });
+      p.endShape();
+      p.pop();
+
+      if (config.enableParticles()) {
+        p.noStroke();
+        particles.forEach((particle) => {
+          particle.x += particle.speed * 0.01;
+          if (particle.x > 1) particle.x = 0;
+          particle.y += Math.sin((particle.life + state.timestamp) * 0.02) * 0.001;
+          particle.life += 1;
+          const px = particle.x * w;
+          const py = centerY + (particle.y - 0.5) * h * 0.5;
+          const alpha = 80 + Math.sin(particle.life * 0.05) * 40;
+          p.fill(255, 255, 255, alpha);
+          p.ellipse(px, py, 6, 2);
+        });
+      }
+
+      if (config.showVectors()) {
+        drawVector(p, centerX, centerY, 0, -state.lift * size * 0.12, '#38bdf8', `${strings.lift} ${state.lift.toFixed(2)}`);
+        drawVector(p, centerX, centerY, 0, state.gravity * size * 0.12, '#f87171', `${strings.gravity} ${state.gravity.toFixed(2)}`);
+        const tensionLength = params.tension * size * 0.15;
+        drawVector(p, centerX, centerY, -tensionLength, tensionLength * 0.2, '#fbbf24', `${strings.tension} ${params.tension.toFixed(2)}`);
+      }
+
+      // 状态标签
+      p.noStroke();
+      p.fill(0, 0, 0, 120);
+      p.rect(w - 190, 24, 166, 90, 12);
+      p.fill(255);
+      p.textSize(14);
+      p.textAlign(p.LEFT, p.TOP);
+      const textLines = [
+        `V=${mapNumber(state.params.wind, 0, 5, 1, 9).toFixed(1)}m/s`,
+        `Pitch=${state.pitch.toFixed(1)}°`,
+        `Vy=${state.velocity.y.toFixed(2)}`
+      ];
+      textLines.forEach((line, index) => {
+        p.text(line, w - 176, 32 + index * 24);
+      });
+
+      if (toastMessage) {
+        p.textAlign(p.CENTER, p.CENTER);
+        const alpha = Math.min(1, toastTimer / 200);
+        p.fill(0, 0, 0, 200 * alpha);
+        p.rect(w / 2 - 140, h - 80, 280, 42, 999);
+        p.fill(255);
+        p.textSize(16);
+        p.text(toastMessage, w / 2, h - 58);
+        toastTimer -= p.deltaTime;
+        if (toastTimer <= 0) {
+          toastMessage = '';
+          toastTimer = 0;
+        }
+      }
+
+      if (state.passed) {
+        p.textAlign(p.CENTER, p.TOP);
+        p.textSize(20);
+        p.fill(255, 255, 255, 220);
+        p.text(strings.stable, w / 2, 40);
+      }
+    };
+  };
+
+  const instance = new p5(sketch, config.container);
+
+  return {
+    showToast(message: string) {
+      toastMessage = message;
+      toastTimer = TOAST_LIFETIME;
+    },
+    destroy() {
+      toastMessage = '';
+      toastTimer = 0;
+      particles.length = 0;
+      instance.remove();
+      if (canvas) {
+        canvas.remove();
+        canvas = null;
+      }
+    }
+  };
+}
+
+function drawVector(p: p5, x: number, y: number, dx: number, dy: number, color: string, label: string) {
+  p.push();
+  p.stroke(color);
+  p.fill(color);
+  p.strokeWeight(3);
+  p.line(x, y, x + dx, y + dy);
+  const angle = Math.atan2(dy, dx);
+  p.push();
+  p.translate(x + dx, y + dy);
+  p.rotate(angle);
+  p.triangle(0, 0, -12, 5, -12, -5);
+  p.pop();
+  p.noStroke();
+  p.textSize(12);
+  p.textAlign(p.LEFT, p.BOTTOM);
+  p.text(label, x + dx + 6, y + dy + 4);
+  p.pop();
+}
+
+function mapNumber(value: number, inMin: number, inMax: number, outMin: number, outMax: number): number {
+  const t = (value - inMin) / (inMax - inMin);
+  return outMin + (outMax - outMin) * t;
+}

--- a/kite-lab/src/theme.css
+++ b/kite-lab/src/theme.css
@@ -1,0 +1,229 @@
+:root {
+  --kite-bg: #fafaf7;
+  --kite-ink: #0f172a;
+  --kite-gray: #334155;
+  --kite-gold: #b3894a;
+  --kite-panel-bg: rgba(255, 255, 255, 0.88);
+  --kite-panel-border: rgba(15, 23, 42, 0.1);
+  --kite-success: #2dd4bf;
+  --kite-danger: #f97316;
+  font-family: 'Noto Sans SC', 'PingFang SC', 'Microsoft YaHei', sans-serif;
+  color: var(--kite-ink);
+  background: var(--kite-bg);
+}
+
+[data-theme='ink'] {
+  --kite-bg: #111827;
+  --kite-ink: #f8fafc;
+  --kite-gray: #cbd5f5;
+  --kite-panel-bg: rgba(17, 24, 39, 0.9);
+  --kite-panel-border: rgba(148, 163, 184, 0.2);
+}
+
+body,
+html {
+  margin: 0;
+  padding: 0;
+  background: var(--kite-bg);
+  color: var(--kite-ink);
+}
+
+#app {
+  width: 100vw;
+  height: 100vh;
+  min-height: 320px;
+  display: flex;
+  align-items: stretch;
+  justify-content: center;
+}
+
+.kite-container {
+  position: relative;
+  display: flex;
+  flex-direction: row;
+  width: 100%;
+  height: 100%;
+  background: var(--kite-bg);
+  color: var(--kite-ink);
+  overflow: hidden;
+}
+
+.kite-canvas {
+  flex: 1 1 60%;
+  position: relative;
+}
+
+.kite-controls {
+  flex: 1 1 40%;
+  max-width: 420px;
+  display: flex;
+  align-items: stretch;
+  justify-content: center;
+  padding: 16px;
+  box-sizing: border-box;
+}
+
+.kite-panel {
+  flex: 1;
+  box-sizing: border-box;
+  padding: 24px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  background: var(--kite-panel-bg);
+  border-left: 1px solid var(--kite-panel-border);
+  border-radius: 18px;
+  backdrop-filter: blur(8px);
+}
+
+.kite-panel h1 {
+  margin: 0;
+  font-size: 24px;
+  font-weight: 600;
+}
+
+.kite-slider {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.kite-slider label {
+  font-size: 14px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 8px;
+}
+
+.kite-slider input[type='range'] {
+  -webkit-appearance: none;
+  width: 100%;
+  height: 6px;
+  border-radius: 999px;
+  background: linear-gradient(90deg, var(--kite-gold), var(--kite-ink));
+  outline: none;
+}
+
+.kite-slider input[type='range']::-webkit-slider-thumb {
+  -webkit-appearance: none;
+  appearance: none;
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  background: var(--kite-bg);
+  border: 2px solid var(--kite-gold);
+  cursor: pointer;
+  transition: transform 0.2s ease;
+}
+
+.kite-slider input[type='range']::-webkit-slider-thumb:hover {
+  transform: scale(1.1);
+}
+
+.kite-toggle {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  font-size: 14px;
+}
+
+.kite-toggle input[type='checkbox'] {
+  width: 42px;
+  height: 22px;
+  border-radius: 999px;
+  background: rgba(15, 23, 42, 0.1);
+  border: 1px solid var(--kite-panel-border);
+  position: relative;
+  appearance: none;
+  cursor: pointer;
+  transition: background 0.2s ease;
+}
+
+.kite-toggle input[type='checkbox']::after {
+  content: '';
+  position: absolute;
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  background: var(--kite-bg);
+  border: 1px solid var(--kite-gold);
+  top: 1px;
+  left: 2px;
+  transition: transform 0.2s ease;
+}
+
+.kite-toggle input[type='checkbox']:checked {
+  background: var(--kite-gold);
+}
+
+.kite-toggle input[type='checkbox']:checked::after {
+  transform: translateX(18px);
+}
+
+.kite-actions {
+  margin-top: auto;
+  display: flex;
+  gap: 12px;
+}
+
+.kite-button {
+  flex: 1;
+  padding: 10px 16px;
+  border-radius: 8px;
+  border: none;
+  background: var(--kite-gold);
+  color: white;
+  font-size: 14px;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.kite-button:active {
+  transform: scale(0.98);
+}
+
+.kite-toast {
+  position: absolute;
+  left: 50%;
+  bottom: 24px;
+  transform: translateX(-50%);
+  padding: 12px 18px;
+  border-radius: 999px;
+  background: rgba(0, 0, 0, 0.75);
+  color: white;
+  font-size: 14px;
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity 0.3s ease;
+}
+
+.kite-toast.visible {
+  opacity: 1;
+}
+
+@media (max-width: 900px) {
+  .kite-container {
+    flex-direction: column;
+  }
+
+  .kite-canvas {
+    flex: 1 1 auto;
+    min-height: 300px;
+  }
+
+  .kite-controls {
+    max-width: none;
+    width: 100%;
+    padding: 12px;
+  }
+
+  .kite-panel {
+    border-left: none;
+    border-top: 1px solid var(--kite-panel-border);
+  }
+
+  .kite-actions {
+    flex-direction: column;
+  }
+}

--- a/kite-lab/src/types.ts
+++ b/kite-lab/src/types.ts
@@ -1,0 +1,83 @@
+/**
+ * 参数配置对象。
+ */
+export interface KiteParams {
+  /** 风势刻度，0-5 之间的整数。 */
+  wind: number;
+  /** 提线角度，单位度。 */
+  angle: number;
+  /** 拉力倍率。 */
+  tension: number;
+}
+
+/**
+ * 初始化配置项。
+ */
+export interface InitOptions {
+  container?: HTMLElement;
+  theme?: 'light' | 'ink' | 'auto';
+  locale?: 'zh' | 'en';
+  mode?: 'learn' | 'quiz';
+  defaultParams?: Partial<KiteParams>;
+  assetsBaseUrl?: string;
+  enableParticles?: boolean;
+  twoParamMode?: boolean;
+  onReady?: () => void;
+  onScore?: (score: Score) => void;
+  onStateChange?: (state: KiteState) => void;
+  onEnd?: () => void;
+}
+
+/**
+ * 当前物理状态。
+ */
+export interface KiteState {
+  params: KiteParams;
+  velocity: { x: number; y: number };
+  position: { x: number; y: number };
+  pitch: number;
+  lift: number;
+  gravity: number;
+  drag: number;
+  stableSeconds: number;
+  attempts: number;
+  passed: boolean;
+  timestamp: number;
+}
+
+/**
+ * 成绩数据。
+ */
+export interface Score {
+  stableSec: number;
+  attempts: number;
+  passed: boolean;
+}
+
+/**
+ * 本地持久化结构。
+ */
+export interface PersistedState {
+  params: KiteParams;
+  score: Score;
+}
+
+export type MessageFromChildType = 'ready' | 'score' | 'state' | 'end';
+export type MessageToChildType =
+  | 'set-theme'
+  | 'set-locale'
+  | 'set-params'
+  | 'reset'
+  | 'get-state';
+
+export interface MessageFromChild<T = unknown> {
+  source: 'kite-lab';
+  type: MessageFromChildType;
+  payload?: T;
+}
+
+export interface MessageToChild<T = unknown> {
+  target: 'kite-lab';
+  type: MessageToChildType;
+  payload?: T;
+}

--- a/kite-lab/src/utils.ts
+++ b/kite-lab/src/utils.ts
@@ -1,0 +1,132 @@
+import type { KiteParams, PersistedState } from './types';
+
+/** 夹取数值。 */
+export function clamp(value: number, min: number, max: number): number {
+  return Math.min(Math.max(value, min), max);
+}
+
+/**
+ * 将风势刻度映射为实际风速（m/s）。
+ */
+export function mapWind(level: number): number {
+  return 1 + clamp(level, 0, 5) * (8 / 5);
+}
+
+/**
+ * 角度转弧度。
+ */
+export function degToRad(deg: number): number {
+  return (deg * Math.PI) / 180;
+}
+
+/**
+ * 弧度转角度。
+ */
+export function radToDeg(rad: number): number {
+  return (rad * 180) / Math.PI;
+}
+
+/** 线性插值。 */
+export function lerp(a: number, b: number, t: number): number {
+  return a + (b - a) * t;
+}
+
+/**
+ * 基于正弦与时间的简单噪声。
+ */
+export function gustNoise(base: number, time: number): number {
+  const noise = Math.sin(time * 0.37 + base * 2.1) * 0.5 + Math.sin(time * 0.11) * 0.3;
+  return 1 + noise * 0.05;
+}
+
+/** 节流函数，确保回调在时间窗内只执行一次。 */
+export function throttle<T extends (...args: never[]) => void>(fn: T, wait: number): T {
+  let timer: number | null = null;
+  let lastArgs: Parameters<T> | null = null;
+  const invoke = () => {
+    if (lastArgs) {
+      fn(...lastArgs);
+      lastArgs = null;
+      timer = window.setTimeout(invoke, wait);
+    } else {
+      timer = null;
+    }
+  };
+  return ((...args: Parameters<T>) => {
+    lastArgs = args;
+    if (timer === null) {
+      fn(...args);
+      timer = window.setTimeout(() => {
+        timer = null;
+        if (lastArgs) {
+          invoke();
+        }
+      }, wait);
+    }
+  }) as T;
+}
+
+const STORAGE_KEY = 'yy.kitelab.state.v1';
+
+/** 读取持久化状态。 */
+export function loadPersistedState(): PersistedState | null {
+  if (typeof window === 'undefined') return null;
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (!raw) return null;
+    return JSON.parse(raw) as PersistedState;
+  } catch (err) {
+    console.warn('[kite-lab] Failed to parse persisted state', err);
+    return null;
+  }
+}
+
+/** 写入持久化状态。 */
+export function savePersistedState(state: PersistedState): void {
+  if (typeof window === 'undefined') return;
+  try {
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(state));
+  } catch (err) {
+    console.warn('[kite-lab] Failed to save state', err);
+  }
+}
+
+/**
+ * 解析 URL hash，返回初始参数。
+ */
+export function parseHashParams(): Partial<KiteParams> {
+  if (typeof window === 'undefined') return {};
+  const hash = window.location.hash.replace(/^#/, '');
+  if (!hash) return {};
+  const result: Partial<KiteParams> = {};
+  hash.split('&').forEach((pair) => {
+    const [key, value] = pair.split('=');
+    const num = Number(value);
+    if (!Number.isFinite(num)) return;
+    if (key === 'wind') result.wind = num;
+    if (key === 'angle') result.angle = num;
+    if (key === 'tension') result.tension = num;
+  });
+  return result;
+}
+
+/**
+ * 将当前参数写入 URL hash。
+ */
+export function writeHashParams(params: KiteParams): void {
+  if (typeof window === 'undefined') return;
+  const hash = `wind=${params.wind.toFixed(2)}&angle=${params.angle.toFixed(2)}&tension=${params.tension.toFixed(2)}`;
+  window.history.replaceState(null, '', `#${hash}`);
+}
+
+/**
+ * 默认参数。
+ */
+export function getDefaultParams(overrides?: Partial<KiteParams>): KiteParams {
+  return {
+    wind: 2,
+    angle: 18,
+    tension: 1,
+    ...overrides
+  };
+}

--- a/kite-lab/test/physics.spec.ts
+++ b/kite-lab/test/physics.spec.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+import { computeLift, isStable, PHYSICS_CONSTANTS } from '../src/physics';
+
+describe('computeLift', () => {
+  it('should increase between 0 and stall angle', () => {
+    const wind = 5;
+    let last = computeLift(wind, 0);
+    for (let alpha = 2; alpha <= PHYSICS_CONSTANTS.stallAlpha; alpha += 2) {
+      const current = computeLift(wind, alpha);
+      expect(current).toBeGreaterThanOrEqual(last);
+      last = current;
+    }
+  });
+
+  it('should decrease after stall angle', () => {
+    const wind = 5;
+    let last = computeLift(wind, PHYSICS_CONSTANTS.stallAlpha);
+    for (let alpha = PHYSICS_CONSTANTS.stallAlpha + 2; alpha <= PHYSICS_CONSTANTS.maxAlpha; alpha += 2) {
+      const current = computeLift(wind, alpha);
+      expect(current).toBeLessThanOrEqual(last + 1e-6);
+      last = current;
+    }
+  });
+});
+
+describe('isStable', () => {
+  it('returns true for stable configuration', () => {
+    const gravity = PHYSICS_CONSTANTS.gravity;
+    expect(isStable(gravity + 0.2, gravity, 0, 0.05)).toBe(true);
+  });
+
+  it('is robust to slight disturbances', () => {
+    const gravity = PHYSICS_CONSTANTS.gravity;
+    expect(isStable(gravity + 0.1, gravity, 4.5, -0.1)).toBe(true);
+    expect(isStable(gravity + 0.05, gravity, 6, 0.14)).toBe(false);
+  });
+});

--- a/kite-lab/tsconfig.json
+++ b/kite-lab/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "useDefineForClassFields": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "strict": true,
+    "jsx": "preserve",
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "types": ["vitest/globals", "p5"]
+  },
+  "include": ["src", "test", "vite.config.ts"],
+  "references": []
+}

--- a/kite-lab/vite.config.ts
+++ b/kite-lab/vite.config.ts
@@ -1,0 +1,31 @@
+import { defineConfig } from 'vite';
+import { resolve } from 'path';
+
+export default defineConfig(() => ({
+  base: './',
+  publicDir: 'public',
+  build: {
+    emptyOutDir: true,
+    cssCodeSplit: false,
+    rollupOptions: {
+      input: resolve(__dirname, 'index.html'),
+      output: [
+        {
+          format: 'es',
+          entryFileNames: 'assets/[name].js',
+          chunkFileNames: 'assets/[name].js',
+          assetFileNames: 'assets/[name][extname]'
+        },
+        {
+          format: 'umd',
+          name: 'KiteLab',
+          entryFileNames: 'kite-lab.umd.js',
+          chunkFileNames: 'kite-lab.[name].js',
+          assetFileNames: 'kite-lab.[name][extname]',
+          inlineDynamicImports: true,
+          exports: 'named'
+        }
+      ]
+    }
+  }
+}));


### PR DESCRIPTION
## Summary
- scaffold a Vite + TypeScript + p5.js single-page Bernoulli kite laboratory with iframe entry and UMD bundle output
- add physics, scene rendering, UI controls, messaging, persistence utilities, and theme styling tailored to the three-parameter interaction
- provide documentation and Vitest coverage for core physics helpers and usage guidance

## Testing
- npm install *(fails: registry denied access to @types/p5 in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d76fb23268832b9e6c8dcbdafbe027